### PR TITLE
Include methods in API reference

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -33,5 +33,6 @@ quartodoc:
   sections:
     - title: CensusAPI
       desc: Core class for connecting to the Census API.
+      package: census21api.wrapper
       contents:
         - CensusAPI


### PR DESCRIPTION
Methods were missing because I had not explicitly included a `package` for the `CensusAPI` item in the `quartodoc` metadata.