### PR TITLE
Fix the category querist

### DIFF
--- a/src/census21api/wrapper.py
+++ b/src/census21api/wrapper.py
@@ -393,7 +393,7 @@ class CensusAPI:
                 item for item in json["items"] if item["id"] == dimension
             )
             categorisations = [
-                cat | {"dimension": dimension} for cat in item["categories"]
+                {**cat, "dimension": dimension} for cat in item["categories"]
             ]
 
             return categorisations

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -87,28 +87,6 @@ def st_feature_queries(draw):
 
 
 @st.composite
-def st_category_queries(draw):
-    """Create a category metadata query pack for testing."""
-
-    population_type = draw(st.sampled_from(POPULATION_TYPES))
-    feature = draw(st.sampled_from(("area-types", "dimensions")))
-    endpoint = "areas" if feature == "area-types" else "categorisations"
-
-    items_by_population_type = (
-        AREA_TYPES_BY_POPULATION_TYPE
-        if feature == "area-types"
-        else DIMENSIONS_BY_POPULATION_TYPE
-    )
-    possible_items = items_by_population_type[population_type]
-    item = draw(st.sampled_from(possible_items))
-
-    num_items = draw(st.integers(1, 5))
-    items = [{"item": st.text()} for _ in range(num_items)]
-
-    return population_type, feature, item, endpoint, items
-
-
-@st.composite
 def st_population_types(draw, include_interested=False):
     """Sample a set of population types and their metadata."""
 
@@ -131,3 +109,40 @@ def st_population_types(draw, include_interested=False):
     )
 
     return population_types, json_metadata, interested
+
+
+@st.composite
+def st_category_queries(draw, feature=None):
+    """Create a category metadata query pack for testing."""
+
+    population_type = draw(st.sampled_from(POPULATION_TYPES))
+    feature = feature or draw(st.sampled_from(("area-types", "dimensions")))
+    num_categories = draw(st.integers(1, 5))
+
+    if feature == "area-types":
+        item = draw(
+            st.sampled_from(AREA_TYPES_BY_POPULATION_TYPE[population_type])
+        )
+        categories = [
+            {
+                "id": draw(st.text()),
+                "label": draw(st.text()),
+                "area_type": item,
+            }
+            for _ in range(num_categories)
+        ]
+
+    if feature == "dimensions":
+        item = draw(
+            st.sampled_from(DIMENSIONS_BY_POPULATION_TYPE[population_type])
+        )
+        categories = [
+            {
+                "categories": [
+                    {"id": draw(st.text()), "label": draw(st.text())}
+                    for _ in range(num_categories)
+                ]
+            }
+        ]
+
+    return population_type, item, categories

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -137,12 +137,8 @@ def st_category_queries(draw, feature=None):
             st.sampled_from(DIMENSIONS_BY_POPULATION_TYPE[population_type])
         )
         categories = [
-            {
-                "categories": [
-                    {"id": draw(st.text()), "label": draw(st.text())}
-                    for _ in range(num_categories)
-                ]
-            }
+            {"id": draw(st.text()), "label": draw(st.text())}
+            for _ in range(num_categories)
         ]
 
     return population_type, item, categories

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -589,7 +589,7 @@ def test_query_dimension_categories_json_valid(params):
         isinstance(categorisation, dict) for categorisation in categorisations
     )
     assert categorisations == [
-        cat | {"dimension": dimension} for cat in categories
+        {**cat, "dimension": dimension} for cat in categories
     ]
 
     get.assert_called_once_with(


### PR DESCRIPTION
The `query_categories()` method only worked for querying area type categories. This PR separates the behaviour out depending on the feature with nice new tests.