### PR TITLE
Update example test following change to blocked pairs

### DIFF
--- a/src/census21api/wrapper.py
+++ b/src/census21api/wrapper.py
@@ -16,7 +16,7 @@ DataLike = Optional[pd.DataFrame]
 
 class CensusAPI:
     """A wrapper for the 2021 England and Wales Census API.
-    
+
     Parameters
     ----------
     verify : bool
@@ -25,7 +25,6 @@ class CensusAPI:
 
     def __init__(self, verify: bool = True) -> None:
         self.verify: bool = verify
-
 
     def _process_response(self, response: Response) -> JSONLike:
         """

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -5,6 +5,29 @@ import pytest
 from census21api import CensusAPI
 
 
+def test_issue_39_blocked_pairs():
+    """
+    https://github.com/datasciencecampus/census21api/issues/39
+
+    This test no longer works as is. See
+    `test_issue_39_blocked_pairs_gets_400_error` for an update to this
+    case. However, we keep this test for posterity, and test that it
+    **doesn't** work.
+    """
+
+    population_type = "UR_HH"
+    area_type = "nat"
+    dimensions = ("economic_activity_status_12a", "industry_current_88a")
+
+    api = CensusAPI()
+
+    with pytest.warns(UserWarning) as w:
+        assert "blocked pair" not in w
+        table = api.query_table(population_type, area_type, dimensions)
+
+    assert table is None
+
+
 def test_issue_39_blocked_pairs_gets_400_error():
     """
     Originally, this was about catching blocked pairs.

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -5,8 +5,16 @@ import pytest
 from census21api import CensusAPI
 
 
-def test_issue_39_blocked_pairs():
-    """https://github.com/datasciencecampus/census21api/issues/39"""
+def test_issue_39_blocked_pairs_gets_400_error():
+    """
+    Originally, this was about catching blocked pairs.
+    
+    See https://github.com/datasciencecampus/census21api/issues/39 for
+    details on the original issue.
+
+    As of 2024-02-16, it seems that blocked pairs now give a 400 error.
+    This test now checks for that.
+    """
 
     population_type = "UR_HH"
     area_type = "nat"
@@ -14,7 +22,7 @@ def test_issue_39_blocked_pairs():
 
     api = CensusAPI()
 
-    with pytest.warns(UserWarning, match="blocked pair"):
+    with pytest.warns(UserWarning, match="Status code: 400"):
         table = api.query_table(population_type, area_type, dimensions)
 
     assert table is None

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -8,7 +8,7 @@ from census21api import CensusAPI
 def test_issue_39_blocked_pairs_gets_400_error():
     """
     Originally, this was about catching blocked pairs.
-    
+
     See https://github.com/datasciencecampus/census21api/issues/39 for
     details on the original issue.
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -26,6 +26,7 @@ from .strategies import (
 
 MOCK_URL = "mock://test.com/"
 
+
 @given(st.booleans())
 def test_init(verify: bool):
     """Test that the `CensusAPI` class can be instantiated correctly."""
@@ -34,7 +35,6 @@ def test_init(verify: bool):
 
     assert isinstance(api, CensusAPI)
     assert vars(api) == {"verify": verify}
-    
 
 
 @given(st.dictionaries(st.text(), st.text()))


### PR DESCRIPTION
See doc-string of test for details:

    Originally, this was about catching blocked pairs.
    
    See https://github.com/datasciencecampus/census21api/issues/39 for
    details on the original issue.

    As of 2024-02-16, it seems that blocked pairs now give a 400 error.
    This test now checks for that.